### PR TITLE
Add default Animator controller support

### DIFF
--- a/Assets/Animation/AnimationCharacterStageAnimationController.cs
+++ b/Assets/Animation/AnimationCharacterStageAnimationController.cs
@@ -19,6 +19,10 @@ public class CharacterStageAnimationController : MonoBehaviour
     public bool autoCheckStageChange = true;
     public float checkInterval = 1f;
 
+    [Header("=== Default Controller ===")]
+    [Tooltip("Fallback controller when Animator has none assigned")]
+    public RuntimeAnimatorController defaultAnimatorController;
+
     // 
     private Animator animator;
     private PlayerController playerController;
@@ -49,6 +53,10 @@ public class CharacterStageAnimationController : MonoBehaviour
         if (animator == null)
         {
             animator = GetComponentInChildren<Animator>();
+        }
+        if (animator != null && animator.runtimeAnimatorController == null && defaultAnimatorController != null)
+        {
+            animator.runtimeAnimatorController = defaultAnimatorController;
         }
         playerController = GetComponent<PlayerController>();
         npcController = GetComponent<NPCController>();


### PR DESCRIPTION
## Summary
- ensure characters have a controller by introducing an optional default controller
- automatically assign the fallback controller when the Animator is missing a controller

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685f6e36cd2483208a6499d18bea9b84