### PR TITLE
feat: add simple dialogue system

### DIFF
--- a/Assets/Scripts/Dialogue/Simple/Condition.cs
+++ b/Assets/Scripts/Dialogue/Simple/Condition.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+
+/// <summary>
+/// Represents a simple condition that must be satisfied based on a
+/// value stored in <see cref="GlobalStateManager"/>.
+/// </summary>
+[System.Serializable]
+public class Condition
+{
+    public string variableName;
+    public Comparison comparison = Comparison.Equal;
+    public int requiredValue;
+
+    public enum Comparison
+    {
+        Equal,
+        NotEqual,
+        GreaterOrEqual,
+        LessOrEqual
+    }
+
+    /// <summary>
+    /// Checks whether this condition is satisfied.
+    /// </summary>
+    public bool IsMet()
+    {
+        var current = GlobalStateManager.Instance.GetInt(variableName);
+        switch (comparison)
+        {
+            case Comparison.Equal:
+                return current == requiredValue;
+            case Comparison.NotEqual:
+                return current != requiredValue;
+            case Comparison.GreaterOrEqual:
+                return current >= requiredValue;
+            case Comparison.LessOrEqual:
+                return current <= requiredValue;
+            default:
+                return false;
+        }
+    }
+}
+

--- a/Assets/Scripts/Dialogue/Simple/Condition.cs.meta
+++ b/Assets/Scripts/Dialogue/Simple/Condition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4f60feffb35945fdab3a904b1217b369

--- a/Assets/Scripts/Dialogue/Simple/DialogueGraph.cs
+++ b/Assets/Scripts/Dialogue/Simple/DialogueGraph.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Collection of dialogue nodes that forms a dialogue tree/graph.
+/// </summary>
+[CreateAssetMenu(menuName = "Dialogue/Simple Graph")]
+public class DialogueGraph : ScriptableObject
+{
+    public List<DialogueNode> nodes = new List<DialogueNode>();
+
+    /// <summary>
+    /// Finds a node by its identifier.
+    /// </summary>
+    public DialogueNode GetNode(string id)
+    {
+        return nodes.Find(n => n != null && n.nodeId == id);
+    }
+}
+

--- a/Assets/Scripts/Dialogue/Simple/DialogueGraph.cs.meta
+++ b/Assets/Scripts/Dialogue/Simple/DialogueGraph.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2168c7fe84724da0bef57683d960c7b7

--- a/Assets/Scripts/Dialogue/Simple/DialogueNode.cs
+++ b/Assets/Scripts/Dialogue/Simple/DialogueNode.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// A single dialogue node containing text and a list of options.
+/// </summary>
+[CreateAssetMenu(menuName = "Dialogue/Simple Node")]
+public class DialogueNode : ScriptableObject
+{
+    public string nodeId;
+    public string speaker;
+    [TextArea(3, 5)]
+    public string text;
+
+    public List<DialogueOption> options = new List<DialogueOption>();
+}
+

--- a/Assets/Scripts/Dialogue/Simple/DialogueNode.cs.meta
+++ b/Assets/Scripts/Dialogue/Simple/DialogueNode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d0260b87b8af4b8fb115b0e05ec82215

--- a/Assets/Scripts/Dialogue/Simple/DialogueOption.cs
+++ b/Assets/Scripts/Dialogue/Simple/DialogueOption.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+/// <summary>
+/// Represents a selectable option in a dialogue node.
+/// It can have conditions and an optional skill check.
+/// </summary>
+[System.Serializable]
+public class DialogueOption
+{
+    [Tooltip("Text shown to the player for this option.")]
+    public string optionText;
+    [Tooltip("The node to jump to when this option is chosen and succeeds.")]
+    public string nextNodeId;
+    [Tooltip("Optional node to jump to if a skill check fails.")]
+    public string failNodeId;
+
+    [Tooltip("Conditions that must be met for this option to be available.")]
+    public Condition[] conditions;
+
+    [Tooltip("Optional skill check that determines success or failure.")]
+    public SkillCheck skillCheck;
+
+    /// <summary>
+    /// Returns true if all conditions are satisfied.
+    /// </summary>
+    public bool AreConditionsMet()
+    {
+        if (conditions == null || conditions.Length == 0)
+            return true;
+
+        foreach (var c in conditions)
+        {
+            if (!c.IsMet())
+                return false;
+        }
+        return true;
+    }
+}
+

--- a/Assets/Scripts/Dialogue/Simple/DialogueOption.cs.meta
+++ b/Assets/Scripts/Dialogue/Simple/DialogueOption.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ecf19f55cb8342c29a6583aa2c227c64

--- a/Assets/Scripts/Dialogue/Simple/GlobalStateManager.cs
+++ b/Assets/Scripts/Dialogue/Simple/GlobalStateManager.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Holds global variables that reflect the player's actions.
+/// This is a lightweight alternative to Ink's variable system.
+/// </summary>
+public class GlobalStateManager : MonoBehaviour
+{
+    /// <summary>
+    /// Singleton instance for easy access.
+    /// </summary>
+    public static GlobalStateManager Instance { get; private set; }
+
+    /// <summary>
+    /// Internal storage for integer variables. Additional types can be
+    /// added as needed.
+    /// </summary>
+    private readonly Dictionary<string, int> intVariables = new Dictionary<string, int>();
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    /// <summary>
+    /// Set an integer variable in the global state.
+    /// </summary>
+    public void SetInt(string key, int value)
+    {
+        intVariables[key] = value;
+    }
+
+    /// <summary>
+    /// Get an integer variable. Returns 0 if the key does not exist.
+    /// </summary>
+    public int GetInt(string key)
+    {
+        return intVariables.TryGetValue(key, out var value) ? value : 0;
+    }
+
+    /// <summary>
+    /// Increase an integer variable by a delta. Useful for counters.
+    /// </summary>
+    public void IncrementInt(string key, int delta = 1)
+    {
+        SetInt(key, GetInt(key) + delta);
+    }
+
+    /// <summary>
+    /// Convenience method for checking if an integer variable is at least
+    /// a required value.
+    /// </summary>
+    public bool IsIntAtLeast(string key, int required)
+    {
+        return GetInt(key) >= required;
+    }
+}
+

--- a/Assets/Scripts/Dialogue/Simple/GlobalStateManager.cs.meta
+++ b/Assets/Scripts/Dialogue/Simple/GlobalStateManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a3e59fe36aea4411a92564cef365bb39

--- a/Assets/Scripts/Dialogue/Simple/SimpleDialogueManager.cs
+++ b/Assets/Scripts/Dialogue/Simple/SimpleDialogueManager.cs
@@ -1,0 +1,102 @@
+using UnityEngine;
+
+/// <summary>
+/// Runtime component that drives a <see cref="DialogueGraph"/>.
+/// This class focuses on the core logic of conditions and skill checks
+/// and leaves UI representation to external scripts.
+/// </summary>
+public class SimpleDialogueManager : MonoBehaviour
+{
+    [Tooltip("Dialogue graph asset containing all nodes.")]
+    public DialogueGraph graph;
+
+    private DialogueNode currentNode;
+
+    /// <summary>
+    /// Start a dialogue at the given node id.
+    /// </summary>
+    public void StartDialogue(string startNodeId)
+    {
+        if (graph == null)
+        {
+            Debug.LogError("[SimpleDialogueManager] No dialogue graph assigned.");
+            return;
+        }
+
+        currentNode = graph.GetNode(startNodeId);
+        if (currentNode == null)
+        {
+            Debug.LogError($"[SimpleDialogueManager] Node {startNodeId} not found.");
+            return;
+        }
+
+        PresentNode();
+    }
+
+    /// <summary>
+    /// Presents the current node. This example implementation logs to the console.
+    /// A real game would connect this to UI elements.
+    /// </summary>
+    private void PresentNode()
+    {
+        if (currentNode == null)
+            return;
+
+        Debug.Log($"{currentNode.speaker}: {currentNode.text}");
+        for (int i = 0; i < currentNode.options.Count; i++)
+        {
+            var opt = currentNode.options[i];
+            if (opt.AreConditionsMet())
+                Debug.Log($"Option {i}: {opt.optionText}");
+        }
+    }
+
+    /// <summary>
+    /// Choose an option from the current node.
+    /// </summary>
+    /// <param name="index">Index of the option.</param>
+    /// <param name="skillValue">Player's skill value used for skill checks.</param>
+    public void ChooseOption(int index, int skillValue = 0)
+    {
+        if (currentNode == null)
+        {
+            Debug.LogWarning("[SimpleDialogueManager] No active dialogue.");
+            return;
+        }
+
+        if (index < 0 || index >= currentNode.options.Count)
+        {
+            Debug.LogWarning("[SimpleDialogueManager] Invalid option index.");
+            return;
+        }
+
+        var option = currentNode.options[index];
+        if (!option.AreConditionsMet())
+        {
+            Debug.Log("[SimpleDialogueManager] Option conditions not met.");
+            return;
+        }
+
+        if (option.skillCheck != null)
+        {
+            bool success = option.skillCheck.Roll(skillValue, out int roll);
+            Debug.Log($"[SimpleDialogueManager] Rolled {roll} against difficulty {option.skillCheck.difficulty} => {(success ? "Success" : "Fail")}");
+            string targetId = success ? option.nextNodeId : option.failNodeId;
+            currentNode = graph.GetNode(targetId);
+        }
+        else
+        {
+            currentNode = graph.GetNode(option.nextNodeId);
+        }
+
+        if (currentNode == null)
+        {
+            Debug.Log("[SimpleDialogueManager] Dialogue ended.");
+        }
+        else
+        {
+            PresentNode();
+        }
+    }
+}
+

--- a/Assets/Scripts/Dialogue/Simple/SimpleDialogueManager.cs.meta
+++ b/Assets/Scripts/Dialogue/Simple/SimpleDialogueManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ae584a3df6b74007948fc1150eca461d

--- a/Assets/Scripts/Dialogue/Simple/SkillCheck.cs
+++ b/Assets/Scripts/Dialogue/Simple/SkillCheck.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+/// <summary>
+/// Handles probability checks similar to Disco Elysium's dice system.
+/// The result determines which dialogue branch will be taken.
+/// </summary>
+[System.Serializable]
+public class SkillCheck
+{
+    public string skillName;
+    [Tooltip("Target number that the dice roll plus skill must meet or exceed.")]
+    public int difficulty = 10;
+    [Tooltip("Number of sides on the dice, defaults to 20 for a d20 roll.")]
+    public int diceSides = 20;
+
+    /// <summary>
+    /// Perform the dice roll using the player's skill value.
+    /// </summary>
+    /// <param name="skillValue">The value of the relevant player skill.</param>
+    /// <param name="roll">The raw dice roll result.</param>
+    /// <returns>True if the check succeeds, false otherwise.</returns>
+    public bool Roll(int skillValue, out int roll)
+    {
+        roll = Random.Range(1, diceSides + 1);
+        int total = roll + skillValue;
+        return total >= difficulty;
+    }
+}
+

--- a/Assets/Scripts/Dialogue/Simple/SkillCheck.cs.meta
+++ b/Assets/Scripts/Dialogue/Simple/SkillCheck.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9a7b35a2d1a04fe2aa015e52cc8697c6


### PR DESCRIPTION
## Summary
- implement GlobalStateManager for story variables
- add DialogueGraph/Node/Option with conditions and skill checks
- introduce SimpleDialogueManager to drive new dialogue system

## Testing
- `dotnet build` (fails: command not found)
- `mcs Assets/Scripts/Dialogue/Simple/*.cs` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a27d0930a88320833084ea4d7caaaa